### PR TITLE
Hotfix/fixes for safari

### DIFF
--- a/src/about/index.ts
+++ b/src/about/index.ts
@@ -9,7 +9,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
     const locateLogo = () => {
 
-        let logoClientRect = logo.contentDocument.getElementById("svg-main").getClientRects()[0];
+        let logoClientRect = logo.contentDocument.getElementById("svg-main").getBoundingClientRect();
         let initHeight = logoClientRect.height;
         let initWidth = logoClientRect.width;
 
@@ -40,7 +40,7 @@ window.addEventListener('DOMContentLoaded', () => {
                 dummy.remove();
                 logo.removeAttribute('style');
 
-                logoClientRect = logo.contentDocument.getElementById("svg-main").getClientRects()[0];
+                logoClientRect = logo.contentDocument.getElementById("svg-main").getBoundingClientRect();
                 initHeight = logoClientRect.height;
                 initWidth = logoClientRect.width;
 

--- a/src/about/style.scss
+++ b/src/about/style.scss
@@ -25,6 +25,7 @@ body {
   height: 75px;
   width: 100%;
   position: sticky;
+  position: -webkit-sticky;
   top: 0;
   display: flex;
   flex-direction: row;


### PR DESCRIPTION
- measure the logo svg size by getBoundingClientRect instead of getClientRects
- make the header sticky for webkit